### PR TITLE
refact!: automatically look for templates under `templates` directory…

### DIFF
--- a/doc/tags
+++ b/doc/tags
@@ -1,8 +1,5 @@
 Templar.nvim	templar.txt	/*Templar.nvim*
-TemplarRegister	templar.txt	/*TemplarRegister*
 templar-fields	templar.txt	/*templar-fields*
 templar-intro	templar.txt	/*templar-intro*
-templar-register	templar.txt	/*templar-register*
 templar-writing	templar.txt	/*templar-writing*
-templar.register	templar.txt	/*templar.register*
 templar.txt	templar.txt	/*templar.txt*

--- a/doc/templar.txt
+++ b/doc/templar.txt
@@ -1,4 +1,4 @@
-*templar.txt*	For Neovim 5.0	Last Change: 2021 feb 24
+*templar.txt*	For Neovim 5.0	Last Change: 2022 jun 14
 
 *Templar.nvim*
 A template manager with field expansion.
@@ -27,55 +27,17 @@ Non-goals~
     1. User interaction during expansion (see goal 2)
 
 ============================================================================
-1. Registering template files
-							    *templar-register*
-
-Registering a template is adding an autocmd to Nvim, which triggers templar
-when a new file of the given extension is opened.
-
-							    *templar.register*
-Use `templar.register(regex [,alias])` lua function to register a new template.
-
-For this, here is a lua example snippet >
-
-    local templar = require'templar'
-    templar.register('*.h')
-    templar.register('*.vim')
-    templar.register('doc/*.txt')
-    templar.register('project/doc/*.txt', 'project_docs')
-
-This registers templates for c headers, vim files and help files.
-When opening a new `.h` file, `templar` wil search for `templates/template.h`
-files in your runtime files.
-In the examples the `doc/*.txt` entry will search in
-`templates/doc/template.txt` in your runtime files.
-In the examples the `project/doc/*.txt` entry will search in
-`templates/project_docs.txt` in your runtime files instead of 
-`templates/project/docs/template.txt`
-
-							     *TemplarRegister*
-If you want do to this from vimscript you can also use the `TemplarRegister`
-command.
-
-    :TemplarRegister {regex}		Registers a new template.
-    :TemplarRegister {regex} {alias}	Registers a new template with alias
-
-Which would turn the lua code above in this >
-
-    TemplarRegister *.h
-    TemplarRegister *.vim
-    TemplarRegister doc/*.txt
-    TemplarRegister project/doc/*.txt project_docs
-
-============================================================================
-2. Writing template files
+1. Writing template files
 							     *templar-writing*
+
+A template file can have any name you want and must be placed into a
+`templates` directory in your configuration root directory.
 
 Lets go throught an example to see how to write a templar template file.
 Consider the examples lua snippet above, and espacially the c header file.
 Here is an example template file for c header >
 
-    #ifndef %{'__' . substitute(toupper(expand('%:t')), '\(\.\|-\)', '_', 0) . '__'}
+    #ifndef %{'__' .. vim.fn.expand("%:t"):upper():gsub("%.", "_"):gsub("%-", "_") .. '__'}
     #define %{0}
 
     %{CURSOR}
@@ -86,12 +48,12 @@ Here is an example template file for c header >
 The syntax is pretty basic, we call every `%{*}` part a field.
 As we see we have 3 types of fields here :
 
-    `%{VimL}`		This fields will be evaluated to the Viml expression
+    `%{Lua}`		This fields will be evaluated to the Lua expression
 			they contain. The value will then be stored in a 0
 			based array so that you can recall their values.
-			Note: In VimL fields, you can see that `expand('%')`
-			will return the file which triggered `BufNewFile`
-			autocommand.
+			Note: In Lua fields, you can see that
+			`vim.fn.expand('%')` will return the file which
+			triggered `BufNewFile` autocommand.
 
     `%{N}`		With these fields you can recall a previously
 			evaluated field. In our example we recall the

--- a/lua/templar.lua
+++ b/lua/templar.lua
@@ -1,24 +1,19 @@
 -- in templar.lua
 
-local api = vim.api
-local templates = {}
+local templates_dir = vim.fn.stdpath("config") .. "/templates"
+
+local templates = vim.fn.readdir(templates_dir)
 
 local function parse_field(field, values)
 	local value
-	if string.match(field, '^%d+$') then
+	if string.match(field, "^%d+$") then
 		value = values[tonumber(field)]
 	else
-		value = vim.fn.eval(field)
+		value = vim.fn.luaeval(field)
 		values[#values] = value
 	end
 
 	return value
-end
-
-local function debug_print(...)
-  if vim.g.templar_debug_print == 1 then
-    print(...)
-  end
 end
 
 local function parse_template(file)
@@ -28,32 +23,29 @@ local function parse_template(file)
 
 	-- Content of the future file
 	local evaluated = {}
-	local actual_cursor = api.nvim_win_get_cursor(0)
+	local actual_cursor = vim.api.nvim_win_get_cursor(0)
 	local future_cursor = nil
 	local values = {}
 
 	for index, line in ipairs(lines) do
-		local tag = vim.fn.matchstr(line, '%{\\zs.\\+\\ze}')
+		local tag = vim.fn.matchstr(line, "%{\\zs.\\+\\ze}")
 
 		if not tag or tag:len() == 0 then
 			evaluated[index] = line
-		elseif tag == 'CURSOR' then
-			future_cursor = {actual_cursor[1] + index - 1, line:find("CURSOR") - 3}
-			evaluated[index] = line:gsub('%%{.+}', '')
-		elseif tag:match('INCLUDE %g+') then
+		elseif tag == "CURSOR" then
+			future_cursor = { actual_cursor[1] + index - 1, line:find("CURSOR") - 3 }
+			evaluated[index] = line:gsub("%%{.+}", "")
+		elseif tag:match("INCLUDE %g+") then
 			-- Special INCLUDE tag
-			-- Includes the content of a templte into current
-			local fname = vim.fn.matchstr(tag, 'INCLUDE \\zs\\f*\\ze')
-			local path = vim.fn.fnamemodify(filename, ':p:h') .. '/' .. fname
-			debug_print(path)
+			-- Includes the content of a template into current
+			local fname = vim.fn.matchstr(tag, "INCLUDE \\zs\\f*\\ze")
+			local path = vim.fn.fnamemodify(filename, ":p:h") .. "/" .. fname
 
 			local _, output = parse_template(path)
 
-			debug_print(vim.inspect(evaluated))
 			vim.list_extend(evaluated, output)
-			debug_print(vim.inspect(evaluated))
 		else
-			evaluated[index] = line:gsub('%%{.+}', parse_field(tag, values))
+			evaluated[index] = line:gsub("%%{.+}", parse_field(tag, values))
 		end
 	end
 	future_cursor = future_cursor or actual_cursor
@@ -62,21 +54,21 @@ end
 
 local function use_template(file)
 	local cursor, lines = parse_template(file)
-	api.nvim_buf_set_lines(0, 0, -1, false, lines)
-	api.nvim_win_set_cursor(0, cursor)
+	vim.api.nvim_buf_set_lines(0, 0, -1, false, lines)
+	vim.api.nvim_win_set_cursor(0, cursor)
 end
 
 -- searches the correct template for the current file
 local function search_template()
-	local curfile = vim.fn.expand('%:p')
+	local curfile_ext = vim.fn.expand("%:e")
 
-    for fname, temppath in pairs(templates) do
-        debug_print(fname, temppath)
-        if curfile:find(fname) ~= nil then
-            local files = api.nvim_get_runtime_file(temppath, false)
-            return files[1]
-        end
-    end
+	for _, template in ipairs(templates) do
+	  local template_ext = vim.split(template, ".", { plain = true })[2]
+		if curfile_ext == template_ext then
+			local files = vim.api.nvim_get_runtime_file("templates/" .. template, false)
+			return files[1]
+		end
+	end
 
 	return nil
 end
@@ -89,18 +81,6 @@ local function source()
 	end
 end
 
--- registers a new file extension to use the template with
-local function register(filename, alias)
-    -- Generate template path from filename or alias
-    -- This is basically replacing each * in the filename by template
-    -- If alias is provided it is appended with extension from filename
-    local fileroot = alias or string.gsub(vim.fn.fnamemodify(filename,':r'), "%*", "template")
-    local temppath = 'templates/' .. fileroot .. '.' .. vim.fn.fnamemodify(filename, ':e')
-    local fname_regex = string.gsub(filename, "%*", ".*") .. "$"
-    templates[fname_regex] = temppath
-end
-
 return {
-	source=source,
-	register=register
+	source = source,
 }

--- a/plugin/templar.vim
+++ b/plugin/templar.vim
@@ -1,4 +1,4 @@
-" Last Change: 2020 mar 30
+" Last Change: 2022 jun 14
 " Author: Thomas Vigouroux
 
 if exists('g:loaded_templar')
@@ -10,6 +10,3 @@ endif
 augroup Templar
     autocmd BufNewFile * lua require'templar'.source()
 augroup END
-
-
-command! -nargs=+ TemplarRegister lua require'templar'.register(<f-args>)


### PR DESCRIPTION
… in the user configuration root directory

This commit removes `templar.register` method since templates are now automatically registered. This change allows persistent templates across multiple Neovim instances without needing to register them again in every instance using `:TemplarRegister` command.

This commit also changes the way fields are evaluated. templar now evaluates Lua expressions instead of VimL expressions, in that way the user can use the best of both worlds to create more powerful templates (accessing VimL functions via `vim.fn`, etc).

Also removed `debug_print` function as I'm not going to use it, and updated documentation.